### PR TITLE
For #3: `extract-major-beta-version` code cleanup

### DIFF
--- a/src/extract-major-beta-version.py
+++ b/src/extract-major-beta-version.py
@@ -16,17 +16,17 @@ from github import Github, InputGitAuthor, enable_console_debug_logging
 
 
 def major_version_from_release_branch_name(branch_name):
-    if matches := re.match(r"^releases[_/]v(\d+)\.0\.0$", branch_name):
+    if matches := re.match(r"^releases_v(\d+)\.0\.0$", branch_name):
         return int(matches[1])
     raise Exception(f"Unexpected release branch name: {branch_name}")
 
 
 def get_release_branches(repo):
     return [branch.name for branch in repo.get_branches()
-            if re.match(r"^releases[_/]v\d+\.0\.0$", branch.name)]
+            if re.match(r"^releases_v\d+\.0\.0$", branch.name)]
 
 
-def get_latest_beta_major_version(repo):
+def get_latest_release_major_version(repo):
     major_versions = [major_version_from_release_branch_name(branch_name)
                             for branch_name in get_release_branches(repo)]
     if len(major_versions) > 0:
@@ -72,22 +72,22 @@ if __name__ == "__main__":
     # - Look at version.txt to make sure that branch is actually in Beta
     #
 
-    last_beta_major_version = get_latest_beta_major_version(repository)
-    if not last_beta_major_version:
-        print(f"[E] Could not determine the latest beta branch of \"{repository}\"")
+    latest_release_major_version = get_latest_release_major_version(repository)
+    if not latest_release_major_version:
+        print(f"[E] Could not determine the latest release branch of \"{repository}\"")
         sys.exit(1)
 
-    branch_name = f"releases_v{last_beta_major_version}.0.0"
+    branch_name = f"releases_v{latest_release_major_version}.0.0"
 
     if verbose:
         print(f"[I] Looking at branch \"{repository}:{branch_name}\"")
 
     if not is_beta_branch(repository, branch_name):
         print(f"Branch \"{repository}:{branch_name}\" is not in beta; returning an empty version")
-        last_beta_major_version = ""
+        latest_release_major_version = ""
 
     if verbose:
-        print(f"[I] Latest major beta version is: \"{last_beta_major_version}\"")
+        print(f"[I] Latest major beta version is: \"{latest_release_major_version}\"")
 
-    print(f"::set-output name=beta_version::{last_beta_major_version}")
+    print(f"::set-output name=beta_version::{latest_release_major_version}")
 


### PR DESCRIPTION
- allow for both naming scheme for branches - with patch version or without.
- hardcode `releases_` as the prefix of all release branches
- refactor `get_latest_beta_major_version` method naming to better express what
it does - get the major version of any latest release branch (not necessarily
beta)

This was tested in both Fenix and Focus to correctly identify the latest release major version:
- Fenix - https://github.com/Mugurell/fenix/runs/6897064446?check_suite_focus=true
- Focus - https://github.com/Mugurell/focus-android/runs/6897061459?check_suite_focus=true
(through publishing the action from a separate repo - https://github.com/Mugurell/TestGithubActions/releases/tag/10.0.1)