### PR TITLE
No issue - Fix unbalanced parenthesis  in release branch name regex

### DIFF
--- a/src/extract-major-beta-version.py
+++ b/src/extract-major-beta-version.py
@@ -17,14 +17,14 @@ from mozilla_version.mobile import MobileVersion
 
 
 def major_version_from_release_branch_name(branch_name):
-    if matches := re.match(r"^releases_v(\d+)$)", branch_name):
+    if matches := re.match(r"^releases_v(\d+)$", branch_name):
         return int(matches[1])
     raise Exception(f"Unexpected release branch name: {branch_name}")
 
 
 def get_release_branches(repo):
     return [branch.name for branch in repo.get_branches()
-            if re.match(r"^releases_v\d+$)", branch.name)]
+            if re.match(r"^releases_v\d+$", branch.name)]
 
 
 def get_latest_release_major_version(repo):


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-android/actions/runs/3745824462/jobs/6360627450

```
Traceback (most recent call last):
  File "/usr/src/app/extract-major-beta-version.py", line 83, in <module>
    latest_release_major_version = get_latest_release_major_version(repository)
  File "/usr/src/app/extract-major-beta-version.py", line 32, in get_latest_release_major_version
    for branch_name in get_release_branches(repo)]
  File "/usr/src/app/extract-major-beta-version.py", line 26, in get_release_branches
    return [branch.name for branch in repo.get_branches()
  File "/usr/src/app/extract-major-beta-version.py", line 27, in <listcomp>
    if re.match(r"^releases_v\d+$)", branch.name)]
  File "/usr/local/lib/python3.10/re.py", line 190, in match
    return _compile(pattern, flags).match(string)
  File "/usr/local/lib/python3.10/re.py", line 303, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/local/lib/python3.10/sre_compile.py", line 788, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/local/lib/python3.10/sre_parse.py", line 969, in parse
    raise source.error("unbalanced parenthesis")
re.error: unbalanced parenthesis at position 1[5](https://github.com/mozilla-mobile/firefox-android/actions/runs/3745824462/jobs/6360627450#step:4:6)
```